### PR TITLE
Set php version on app creation and set IN_PLACE_DEPLOYMENT

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -54,12 +54,14 @@
         "name": "[parameters('siteName')]",
         "serverFarmId": "[parameters('hostingPlanName')]",
         "siteConfig": {
+          "phpVersion": "5.5",
           "localMySqlEnabled": true,
            "appSettings": [
             { "name": "WEBSITE_MYSQL_ENABLED", "value": "1" },
             { "name": "WEBSITE_MYSQL_GENERAL_LOG", "value": "0" },
             { "name": "WEBSITE_MYSQL_SLOW_QUERY_LOG", "value": "0" },
-            { "name": "WEBSITE_MYSQL_ARGUMENTS", "value": "--max_allowed_packet=16M" }
+            { "name": "WEBSITE_MYSQL_ARGUMENTS", "value": "--max_allowed_packet=16M" },
+            { "name": "IN_PLACE_DEPLOYMENT", "value": "1" }
           ]
         }
       },
@@ -75,18 +77,6 @@
             "RepoUrl": "[parameters('repoUrl')]",
             "branch": "[parameters('branch')]",
             "IsManualIntegration": true
-          }
-        },
-        {
-          "apiVersion": "2014-06-01",
-          "name": "web",
-          "type": "config",
-          "dependsOn": [
-            "[concat('Microsoft.Web/sites/', parameters('siteName'))]"
-          ],
-          "properties": {
-           
-            "phpVersion": "5.5"
           }
         }
       ]


### PR DESCRIPTION
setting php version after source control could cause the app to restart. 

this repo contains 14k files. Normal deployment flow is to clone the repo under `D:\home\site\repository` then copy that to `D:\home\site\wwwroot`, but with 14k files and slow XDrives this can take over 20 minutes. Setting `IN_PLACE_DEPLOYMENT` clones the repo under `D:\home\site\wwwroot` directly which cuts the deployment time from ~25 minutes to 4 minutes. Git still takes a while to unpack 14k files